### PR TITLE
fix: Fix response body bug causing error to app users

### DIFF
--- a/.github/workflows/update-code.yaml
+++ b/.github/workflows/update-code.yaml
@@ -35,7 +35,7 @@ jobs:
     with:
       environment: ${{ github.event.inputs.environment }}
       lambda_function_name: rsp-nonprod-apis-notify-${{ matrix.lambdaName }}
-      bucket_key: notify/${{ matrix.lambdaName }}/${{ github.event.inputs.zip_archive }}.zip
+      bucket_key: notify/${{ matrix.lambdaName }}/${{ github.event.inputs.zip_archive }}
     permissions:
       id-token: write
     secrets:

--- a/src/services/notifyService.js
+++ b/src/services/notifyService.js
@@ -22,7 +22,7 @@ export default class Notify {
 				},
 			);
 			logInfo('SendSmsSuccess', {
-				notifyMessageId: response.body.id,
+				notifyMessageId: response.data ? response.data.id : 'no id found',
 			});
 			return Notify.SuccessfulResponse();
 		} catch (error) {
@@ -50,7 +50,7 @@ export default class Notify {
 			);
 
 			logInfo('SendEmailSuccess', {
-				notifyMessageId: response.body.id,
+				notifyMessageId: response.data ? response.data.id : 'no id found',
 			});
 			return Notify.SuccessfulResponse();
 		} catch (error) {
@@ -75,11 +75,17 @@ export default class Notify {
 	}
 
 	static formatErrorObject(errorResponse) {
-		// eslint-disable-next-line no-console
-		console.error(errorResponse);
+		if (errorResponse.response && errorResponse.response.data) {
+			return {
+				statusCode: errorResponse.response.data.status_code,
+				errors: errorResponse.response.data.errors,
+			};
+		}
 		return {
-			statusCode: errorResponse.error.status_code,
-			errors: errorResponse.error.errors,
+			errors: [{
+				error: 'RSPError',
+				message: `An unexpected error occurred. ${errorResponse.message ? errorResponse.message : ''}`,
+			}],
 		};
 	}
 

--- a/src/test/services/notifyService.unit.js
+++ b/src/test/services/notifyService.unit.js
@@ -2,13 +2,14 @@
 import expect from 'expect';
 import sinon from 'sinon';
 import { NotifyClient } from 'notifications-node-client';
-
+import * as logger from '../../utils/logger';
 import config from '../../utils/config';
 import NotifyService from '../../services/notifyService';
 import TemplateKeySelector from '../../utils/TemplateKeySelector';
 
 describe('notifyService', () => {
 	context('notifyEmail', () => {
+		let logStub;
 		let sendEmailStub;
 		let templateKeySelectorStub;
 		let personalisation;
@@ -24,7 +25,7 @@ describe('notifyService', () => {
 		};
 
 		beforeEach(() => {
-			sinon.stub(console, 'log');
+			logStub = sinon.stub(logger, 'logInfo');
 			personalisation = personalisationWithLink('https://portal.local/47bmo7p9syg');
 			sendEmailStub = sinon.stub(NotifyClient.prototype, 'sendEmail');
 			templateKeySelectorStub = sinon.stub(TemplateKeySelector.prototype, 'keyForEmail');
@@ -37,6 +38,7 @@ describe('notifyService', () => {
 			TemplateKeySelector.prototype.keyForEmail.restore();
 			config.paymentPortalUrl.restore();
 			config.notifyApiKey.restore();
+			logStub.restore();
 		});
 
 		context('when called with email, full payload for English language and respond', () => {
@@ -46,21 +48,29 @@ describe('notifyService', () => {
 					.returns('ENGLISH_EMAIL_TEMPLATE_KEY');
 				sendEmailStub
 					.withArgs('ENGLISH_EMAIL_TEMPLATE_KEY', emailAddr, personalisation)
-					.resolves({ body: { id: 'gov-notify-message-id' } });
+					.resolves({ data: { id: 'gov-notify-message-id' } });
 			});
 			it('should call the notify client correctly then respond', async () => {
 				const response = await NotifyService.email(emailAddr, payload);
 				sinon.assert.calledWith(sendEmailStub, 'ENGLISH_EMAIL_TEMPLATE_KEY', emailAddr, personalisation);
 				expect(response).toMatchObject({ statusCode: 200 });
 			});
+			it('should call the notify client and log the message id', async () => {
+				await NotifyService.email(emailAddr, payload);
+				sinon.assert.calledWith(logStub, 'SendEmailSuccess', { notifyMessageId: 'gov-notify-message-id' });
+			});
 		});
 	});
 
 	context('notifySms', () => {
+		let logInfoStub;
+		let logErrorStub;
 		let sendSmsStub;
 		let templateKeySelectorStub;
 
 		beforeEach(() => {
+			logInfoStub = sinon.stub(logger, 'logInfo');
+			logErrorStub = sinon.stub(logger, 'logError');
 			sendSmsStub = sinon.stub(NotifyClient.prototype, 'sendSms');
 			templateKeySelectorStub = sinon.stub(TemplateKeySelector.prototype, 'keyForSms');
 			sinon.stub(config, 'paymentPortalUrl').returns('https://portal.local');
@@ -72,6 +82,8 @@ describe('notifyService', () => {
 			TemplateKeySelector.prototype.keyForSms.restore();
 			config.paymentPortalUrl.restore();
 			config.notifyApiKey.restore();
+			logInfoStub.restore();
+			logErrorStub.restore();
 		});
 
 		context('when called with phone number, full payload for English language and respond', () => {
@@ -84,12 +96,93 @@ describe('notifyService', () => {
 					.returns('ENGLISH_SMS_TEMPLATE_KEY');
 				sendSmsStub
 					.withArgs('ENGLISH_SMS_TEMPLATE_KEY', '12345', personalisation)
-					.resolves({ body: { id: 'gov-notify-message-id' } });
+					.resolves({ data: { id: 'gov-notify-message-id' } });
 			});
 			it('should call the notify client correctly then respond', async () => {
 				const response = await NotifyService.sms('12345', smsPayloadForLanguage('en'));
 				sinon.assert.calledWith(sendSmsStub, 'ENGLISH_SMS_TEMPLATE_KEY', '12345', personalisation);
 				expect(response).toMatchObject({ statusCode: 200 });
+			});
+			it('should call the notify client and log the message id', async () => {
+				await NotifyService.sms('12345', smsPayloadForLanguage('en'));
+				sinon.assert.calledWith(logInfoStub, 'SendSmsSuccess', { notifyMessageId: 'gov-notify-message-id' });
+			});
+		});
+
+		context('when error is returned, it is handled correctly', () => {
+			let personalisation;
+
+			beforeEach(() => {
+				personalisation = personalisationWithLink('https://portal.local/47bmo7p9syg');
+				templateKeySelectorStub
+					.withArgs('en')
+					.returns('ENGLISH_SMS_TEMPLATE_KEY');
+				sendSmsStub
+					.withArgs('ENGLISH_SMS_TEMPLATE_KEY', '12345', personalisation)
+					.rejects({
+						response: {
+							data: {
+								status_code: 400,
+								errors: [{
+									error: 'BadRequestError',
+									message: "Can't send to this recipient using a team-only API key",
+								}],
+							},
+						},
+					});
+			});
+			it('should fail to send through the notify client and return the error', async () => {
+				const response = await NotifyService.sms('12345', smsPayloadForLanguage('en'));
+				expect(response).toMatchObject({
+					statusCode: 400,
+					body: JSON.stringify({
+						statusCode: 400,
+						errors: [{
+							error: 'BadRequestError',
+							message: "Can't send to this recipient using a team-only API key",
+						}],
+					}),
+				});
+			});
+			it('should call the notify client and call the error logger', async () => {
+				await NotifyService.sms('12345', smsPayloadForLanguage('en'));
+				sinon.assert.calledWith(logErrorStub, 'SendSmsError', {
+					notifyApiError: {
+						statusCode: 400,
+						errors: [
+							{
+								error: 'BadRequestError',
+								message: "Can't send to this recipient using a team-only API key",
+							},
+						],
+					},
+				});
+			});
+		});
+
+		context('when an unexpected error occurs, it is handled correctly', () => {
+			let personalisation;
+
+			beforeEach(() => {
+				personalisation = personalisationWithLink('https://portal.local/47bmo7p9syg');
+				templateKeySelectorStub
+					.withArgs('en')
+					.returns('ENGLISH_SMS_TEMPLATE_KEY');
+				sendSmsStub
+					.withArgs('ENGLISH_SMS_TEMPLATE_KEY', '12345', personalisation)
+					.rejects(new Error('Something unexpected happened'));
+			});
+			it('should fail with unexpected error and handle error gracefully to the user', async () => {
+				const response = await NotifyService.sms('12345', smsPayloadForLanguage('en'));
+				expect(response).toMatchObject({
+					statusCode: 400,
+					body: JSON.stringify({
+						errors: [{
+							error: 'RSPError',
+							message: 'An unexpected error occurred. Something unexpected happened',
+						}],
+					}),
+				});
 			});
 		});
 


### PR DESCRIPTION
## Description

- Currently an error gets thrown when logging out message id from Notify library which results in an error getting returned back to the users app even though the email or sms is sent out correctly
- Notify npm package upgrade to version 5 changed the repsonse body and error repsonse object shape. See [changelog](https://github.com/alphagov/notifications-node-client/blob/main/CHANGELOG.md#500---2020-09-02) for full details.
- Updated the response `body` object to `data`
- Updated the error response `error` to `response.data`
- Added new unit tests around logging and error handling
- Removed extra `.zip` being appended to file names in the upload code workflow

Related issue: [RSP-2103](https://dvsa.atlassian.net/browse/RSP-2103) and [RSP-2104](https://dvsa.atlassian.net/browse/RSP-2104)

## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [x] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
