### PR TITLE
ci: added release-please action to release.yaml

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,17 +1,33 @@
 name: Release
 
 on:
-  release:
-    types: [published]
+  push:
+    branches:
+      - master
 
 env:
   SOURCE_ZIP: master.zip
   KEY_PATH: notify
 
 jobs:
+  release-please:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    outputs:
+      tag_name: ${{ steps.release.outputs.tag_name }}
+      release_created: ${{ steps.release.outputs.release_created }}
+    steps:
+      - uses: google-github-actions/release-please-action@v3
+        id: release
+        with:
+          release-type: node
+          package-name: rsp-gov-notify
 
   lambdas:
     runs-on: ubuntu-latest
+    needs: release-please
     outputs:
       matrix: ${{ steps.json.outputs.MATRIX }}
     steps:
@@ -20,11 +36,13 @@ jobs:
         id: json
         run: |
           echo "MATRIX=$(jq -c . < ./lambdas.json)" >> $GITHUB_OUTPUT
+
   promote:
     runs-on: ubuntu-latest
+    if: ${{ needs.release-please.outputs.release_created }}
     permissions:
       id-token: write
-    needs: [ lambdas ]
+    needs: [ lambdas, release-please ]
     strategy:
       matrix:
         lambdaName: ${{ fromJSON(needs.lambdas.outputs.matrix).lambdas }}
@@ -41,5 +59,5 @@ jobs:
           --tagging-directive REPLACE
           --tagging promote=YES
           --copy-source ${{ secrets.RSP_NONPROD_S3_BUCKET_NAME }}/${{ env.KEY_PATH }}/${{ matrix.lambdaName }}/${{ env.SOURCE_ZIP }}
-          --key ${{ env.KEY_PATH }}/${{ matrix.lambdaName }}/release-${{ github.ref_name }}.zip
+          --key ${{ env.KEY_PATH }}/${{ matrix.lambdaName }}/release-${{ needs.release-please.outputs.tag_name }}.zip
           --bucket ${{ secrets.RSP_NONPROD_S3_BUCKET_NAME }}


### PR DESCRIPTION
## Description

- Modified workflow to run on pushes to master branch
- Added job to run release-please action
- Modified promote job to require completion of release-please, and only run when release-please outputs a created release (ie when a release PR is merged)

Related issue: [RSP-2185](https://dvsa.atlassian.net/browse/RSP-2185?atlOrigin=eyJpIjoiNWZhMGFiYzIwMzQ3NDJhMDlmYjc2NDhhZTI0M2JmNjEiLCJwIjoiaiJ9)

## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
